### PR TITLE
Update GoogleAPIController.php / Issue 12

### DIFF
--- a/lib/Controller/GoogleAPIController.php
+++ b/lib/Controller/GoogleAPIController.php
@@ -246,7 +246,7 @@ class GoogleAPIController extends Controller {
 		if ($this->accessToken === '') {
 			return new DataResponse('', 400);
 		}
-		$result = $this->googleCalendarAPIService->registerSyncCalendar($this->accessToken, $this->userId, $calId, $calName, $color);
+		$result = $this->googleCalendarAPIService->registerSyncCalendar($this->userId, $calId, $calName, $color);
 		$response = new DataResponse($result, 200);
 		return $response;
 	}


### PR DESCRIPTION
The parameter count in the method call doesnt match the definition in the target.

Neither i think the token is a good choice to store as user id.


https://github.com/MarcelRobitaille/nextcloud_google_synchronization/issues/12

> See Method Code in 
https://github.com/MarcelRobitaille/nextcloud_google_synchronization/blob/master/lib/Service/GoogleCalendarAPIService.php
Line 427