### PR TITLE
fix: don't wipe the whole calendar when a Google fetch fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Fixed
+
+- Do not wipe the whole calendar when fetching events from Google fails. A transient error (expired token / 401, DNS failure, 5xx, rate limiting) made the events list come back empty, which was interpreted as "everything was deleted in Google" and removed every local event. The import now aborts on a fetch error instead of deleting. @IT-BAER
+
 ## [4.2.0] - 2026-06-17
 
 ### Changed

--- a/lib/Service/GoogleCalendarAPIService.php
+++ b/lib/Service/GoogleCalendarAPIService.php
@@ -338,7 +338,7 @@ class GoogleCalendarAPIService {
 	 * @param string $calId
 	 * @param string $calName
 	 * @param ?string $color
-	 * @return array{nbAdded: int, nbUpdated: int, calName: string}
+	 * @return array{error: string}|array{nbAdded: int, nbUpdated: int, calName: string}
 	 */
 	public function importCalendar(string $userId, string $calId, string $calName, ?string $color = null): array {
 		$params = [];
@@ -389,6 +389,20 @@ class GoogleCalendarAPIService {
 			} else {
 				array_push($events, $e);
 			}
+		}
+
+		// If fetching the events from Google failed, the generator yields nothing
+		// and returns an error. Aborting here is essential: otherwise the empty
+		// result is interpreted as "every event was deleted in Google" and the
+		// deletion loop below wipes the entire calendar on a transient failure
+		// (expired token / 401, DNS hiccup, 5xx, rate limiting, ...).
+		$eventGeneratorReturn = $eventsGenerator->getReturn();
+		if (isset($eventGeneratorReturn['error'])) {
+			$this->logger->warning(
+				'Aborting calendar import for "' . $calId . '" because fetching events failed: ' . $eventGeneratorReturn['error'],
+				['app' => Application::APP_ID],
+			);
+			return $eventGeneratorReturn;
 		}
 
 		$nbAdded = 0;
@@ -462,10 +476,6 @@ class GoogleCalendarAPIService {
 			$this->caldavBackend->deleteCalendarObject($ncCalId, $uri, $this->caldavBackend::CALENDAR_TYPE_CALENDAR, true);
 		}
 
-		$eventGeneratorReturn = $eventsGenerator->getReturn();
-		if (isset($eventGeneratorReturn['error'])) {
-			/* return $eventGeneratorReturn; */
-		}
 		return [
 			'nbAdded' => $nbAdded,
 			'nbUpdated' => $nbUpdated,


### PR DESCRIPTION
## Problem

`importCalendar()` treats the Google fetch as authoritative: it records every existing event URI as "unseen", un-marks the ones Google returns, then **deletes everything still unseen** ("anything still unseen was deleted in Google Calendar").

`getCalendarEvents()` `return`s early (yielding nothing) on any API error. So when a fetch fails for a transient reason (expired token / `401`, DNS resolution failure, `5xx`, rate limiting), the event list comes back empty, every existing URI stays "unseen", and the deletion loop **wipes the entire calendar**.

The only guard was commented out, so the delete loop ran unconditionally:

```php
$eventGeneratorReturn = $eventsGenerator->getReturn();
if (isset($eventGeneratorReturn['error'])) {
    /* return $eventGeneratorReturn; */
}
```

Since the import is a `TimedJob` running every cron tick, this oscillates: a good fetch refills the calendar, the next failed fetch wipes it. Hit in production on Nextcloud 33 after an OAuth access token expired, ~960 events were deleted, restored, and deleted again every 5 minutes until the token was renewed.

## Fix

Check the events generator's return for an error **before** the add/delete logic runs, and abort the import (returning the error) when the fetch failed. A transient sync failure becomes a no-op instead of data loss. Also removes the dead commented-out check and widens the return type to include the error array.

## Notes

- No behaviour change on a successful sync.
- Covers partial-pagination failures too: if a later page errors mid-iteration, the generator returns the error and the import aborts without deleting.
